### PR TITLE
Fix uneven trailing whitespace in strings

### DIFF
--- a/src/levels.jl
+++ b/src/levels.jl
@@ -26,7 +26,7 @@ for L in (:NotSet, :All, :Off, :Trace, :Notice, :Critical, :Alert, :Emergency, :
     @doc """
         $($L_name)
 
-    
+
         Alias for [`$($L)`](@ref LogLevel)""" $L
     end
 end


### PR DESCRIPTION
Found as part of JuliaLang/julia#46372 - the reference parser treats lines of uneven whitespace in a weird inconsistent way so there's some differences in whitespace in the final deindented string. This change removes those differences.